### PR TITLE
We're on GitHub now (+ minor doc improvements)

### DIFF
--- a/Other/Source/Manual/advanced/development.rst
+++ b/Other/Source/Manual/advanced/development.rst
@@ -8,39 +8,37 @@ If you want to test features of the PortableApps.com Launcher, or get
 development builds in between releases, you'll need to get it and compile the
 Generator. Here's how.
 
-.. _hg:
+.. _src:
 
 The PortableApps.com Launcher source repository
 ===============================================
 
-Development of the PortableApps.com Launcher takes place in a Mercurial_
-repository at SourceForge_. The URL is
-http://portableapps.hg.sourceforge.net/hgweb/portableapps/launcher/. To check
-out ("clone") a copy of the repository, you will need Mercurial_ or TortoiseHg_.
+Development of the PortableApps.com Launcher takes place in a Git_ repository
+at GitHub_. The URL is https://github.com/PortableApps/Launcher.git. To check
+out ("clone") a copy of the repository, you will need Git_ or TortoiseGit_.
 
-To clone the repository with Mercurial,
+To clone the repository with Git,
 
 .. code-block:: bash
 
-   hg clone http://portableapps.hg.sourceforge.net/hgweb/portableapps/launcher
-   cd launcher
+   git clone https://github.com/PortableApps/Launcher.git
+   cd Launcher
 
 (To use a different directory name, put the directory name at the end of the
-``hg clone`` line after a space.)
+``git clone`` line after a space.)
 
-To clone the repository with TortoiseHg, create a directory, right click on it
-in Explorer and find the TortoiseHg "Clone..." option. Specify the path to clone
-as ``http://portableapps.hg.sourceforge.net/hgweb/portableapps/launcher/``.
+To clone the repository with TortoiseGit, create a directory, right click on it
+in Explorer and find the TortoiseGit "Clone..." option. Specify the path to
+clone as ``https://github.com/PortableApps/Launcher.git``.
 
 You can also get a copy of the latest version in this repository without
-Mercurial in the bz2_, gzip_ or zip_ formats.
+Git in the zip_ or gzip_ formats.
 
-.. _Mercurial: http://mercurial.selenic.com
-.. _SourceForge: http://sourceforge.net
-.. _TortoiseHg: http://tortoisehg.bitbucket.org
-.. _bz2: http://portableapps.hg.sourceforge.net/hgweb/portableapps/launcher/archive/tip.tar.bz2
-.. _gzip: http://portableapps.hg.sourceforge.net/hgweb/portableapps/launcher/archive/tip.tar.gz
-.. _zip: http://portableapps.hg.sourceforge.net/hgweb/portableapps/launcher/archive/tip.zip
+.. _Git: http://git-scm.com
+.. _GitHub: http://github.com
+.. _TortoiseGit: http://tortoisegit.org
+.. _zip: http://github.com/PortableApps/Launcher/archive/master.zip
+.. _gzip: http://github.com/PortableApps/Launcher/archive/master.tar.gz
 
 .. _compile-pal-generator:
 
@@ -52,7 +50,7 @@ will need NSIS Portable to compile it (it has the necessary plug-ins included).
 
 1. :ref:`Install the PortableApps.com Launcher <install-launcher>`. Instead of
    installing the PortableApps.com Launcher package, you can get a copy of the
-   :ref:`source repository <hg>`.
+   :ref:`source repository <src>`.
 
 2. Run NSIS Portable and compile ``Other\Source\GeneratorWizard.nsi``
    from the PortableApps.com Launcher source.

--- a/Other/Source/Manual/advanced/segments.rst
+++ b/Other/Source/Manual/advanced/segments.rst
@@ -36,7 +36,7 @@ Hooks
 -----
 
 Here is a list of the hooks which can be executed (in the order in which they
-are called:
+are called):
 
 * ``.onInit``: things which must go in the NSIS ``.onInit`` function (see the
   `NSIS documentation`_ for details about ``.onInit``)
@@ -64,7 +64,7 @@ are called:
   related things in here.
 * ``Unload``: unload plug-ins and clean up traces from the launcher itself.
 
-.. _`NSIS documentation`: http://nsis.sourceforge.net/Docs/Chapter4.html#4.7.2.1.2
+.. _`NSIS documentation`: http://nsis.sourceforge.net/Docs/Chapter4.html#oninit
 
 .. _segments-disable:
 

--- a/Other/Source/Manual/ref/launcher.ini/filewriten.rst
+++ b/Other/Source/Manual/ref/launcher.ini/filewriten.rst
@@ -165,9 +165,9 @@ Context
 
 ----
 
-The format string used to during search and replacement. It is used to
-contextualize the paths, as sometimes the path by itself can not be
-enough in order to correctly perform the updates.
+The format string used during search and replacement. It is used to
+contextualize the paths, as sometimes the path by itself is not
+enough to correctly perform the updates.
 
 A ``%Paths%`` in the context string is replaced with the value of the path
 variable.

--- a/Other/Source/Manual/ref/paf/appinfo.rst
+++ b/Other/Source/Manual/ref/paf/appinfo.rst
@@ -177,7 +177,7 @@ the app only needs Client Profile. If it needs the full framework, that can be
 specified as 4.0F. If .NET is not needed, this value should be omitted.
 
 *Please note that PortableApps.com does not currently accept .NET-based apps for
-inclusion in our application listings. Most PCs "in the wild" do not have .NET
+inclusion in our application listings. Many PCs "in the wild" do not have .NET
 available, so portable apps that require .NET will not function on them.*
 
 .. _paf-appinfo-control:

--- a/Other/Source/Manual/releases/2.1.rst
+++ b/Other/Source/Manual/releases/2.1.rst
@@ -218,5 +218,5 @@ In custom code, the macro ``${ReadUserOverrideConfig}`` has been renamed to
 
 None of these changes are backwards-incompatible insofar as the Generator will
 upgrade the paths and macro name when you first run it. Developers who are
-using the :ref:`development version of the PortableApps.com Launcher <hg>` will
+using the :ref:`development version of the PortableApps.com Launcher <src>` will
 need to :ref:`recompile the Generator <compile-pal-generator>`.

--- a/Other/Source/Manual/topics/64-bit.rst
+++ b/Other/Source/Manual/topics/64-bit.rst
@@ -77,7 +77,7 @@ additional environment variables ``FullAppDir:ForwardSlash``, :ref:`etc.
    http://portableapps.com/apps/utilities/jkdefrag_portable
 
 .. _`7-Zip Portable`:
-   http://portableapps.com/apps/utilities/7zip_portable
+   http://portableapps.com/apps/utilities/7-zip_portable
 
 .. _`64-bit Software: Where It Fits Into Portable Apps`:
    http://portableapps.com/node/24371


### PR DESCRIPTION
We've moved to Git on Github, so we should probably update the documentation so that it doesn't say to use Mercurial (hg) on SourceForge.

Also, there were a couple of broken links and a few minor issues (missing `)`, bad grammar, "Most" vs "Many") which I've included fixes for in this PR. 